### PR TITLE
More fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This role installs Portainer using Docker container
 ## Requirements
 
 - `curl`
+- `docker` (Service + python package)
 
 ## Role Vars
 name | description | default |
@@ -41,8 +42,13 @@ ansible-playbook -i myinventory ./playbooks/deploy-portainer.yml
 
 - hosts: myhosts
   become: true
+  vars:
+    pip_install_packages:
+      - name: docker
   vars_files:
     - vars/portainer.yml
   roles:
+   - geerlingguy.docker
+   - geerlingguy.pip
    - portainer
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ remove_persistent_data: false
 remove_existing_container: false
 persistent_data_path: /opt/portainer:/data
 container_labels: {}
+container_network:
 container_restart_policy: always
 container_recreate: false
 auth_method: 1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,8 +22,10 @@ allow_privileged_users: true
 
 # Networking
 host_port: 9000
+container_ports:
+  - "9000:9000"
 vlan_interface: "{{ hostvars[inventory_hostname]['ansible_' + 'eth1.50']['ipv4']['address'] }}"
-portainer_endpoint: "http://{{ vlan_interface }}:{{ host_port }}/api"
+#portainer_endpoint: "http://{{ vlan_interface }}:{{ host_port }}/api"
 
 # Admin User
 admin_user: admin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,8 +24,6 @@ allow_privileged_users: true
 host_port: 9000
 container_ports:
   - "9000:9000"
-vlan_interface: "{{ hostvars[inventory_hostname]['ansible_' + 'eth1.50']['ipv4']['address'] }}"
-#portainer_endpoint: "http://{{ vlan_interface }}:{{ host_port }}/api"
 
 # Admin User
 admin_user: admin

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -27,7 +27,7 @@ scenario:
     - create
     - prepare
     - converge
-    # - idempotence
+    - idempotence
     - side_effect
     - verify
     - destroy

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -15,4 +15,4 @@
     admin_user: admin
     admin_password: admin
     endpoints:
-      - {name: portainer-mgmt, url: "unix:///var/run/docker.sock"}
+      - {name: local, url: ""}

--- a/tasks/endpoints.yml
+++ b/tasks/endpoints.yml
@@ -38,7 +38,7 @@
 
 - name: Verifying calls
   fail:
-    msg: "Could not add endpoint: {{ item.item.name }} (Error: ...)"
-  failed_when: item.skipped is defined or ((item.stdout is defined) and (item.stdout|from_json).err is not defined)
+    msg: "Could not add endpoint: {{ item.item.name }}"
+  when: item.stdout is defined and (item.stdout|from_json).err is defined
   with_items:
     - "{{ response.results }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,6 +9,7 @@
     recreate: "{{ container_recreate }}"
     restart_policy: "{{ container_restart_policy }}"
     links: "{{ container_links | default(omit) }}"
+    networks: "{{ container_network | default(omit) }}"
     published_ports:
       - "{{ host_port }}:9000"
     volumes:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,16 +9,16 @@
     recreate: "{{ container_recreate }}"
     restart_policy: "{{ container_restart_policy }}"
     links: "{{ container_links | default(omit) }}"
-    networks: "{{ container_network | default(omit) }}"
+    networks: "{{ container_network | default(omit, True) }}"
     published_ports: "{{ container_ports | default(omit, True) }}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - "{{ persistent_data_path }}"
   register: portainer_docker
 
-#- name: "Debug return values from docker_container"
-#  debug:
-#    msg: "{{ portainer_docker.ansible_facts.docker_container }}"
+# - name: "Debug return values from docker_container"
+#   debug:
+#     msg: "{{ portainer_docker.ansible_facts.docker_container }}"
 
 - set_fact:
     portainer_is_running: "{{ portainer_docker.ansible_facts.docker_container.State.Running }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,13 +10,27 @@
     restart_policy: "{{ container_restart_policy }}"
     links: "{{ container_links | default(omit) }}"
     networks: "{{ container_network | default(omit) }}"
-    published_ports:
-      - "{{ host_port }}:9000"
+    published_ports: "{{ container_ports | default(omit, True) }}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - "{{ persistent_data_path }}"
+  register: portainer_docker
 
-- name: Wait for container
-  wait_for:
-    port: "{{ host_port }}"
-    host: "{{ inventory_hostname }}"
+#- name: "Debug return values from docker_container"
+#  debug:
+#    msg: "{{ portainer_docker.ansible_facts.docker_container }}"
+
+- set_fact:
+    portainer_is_running: "{{ portainer_docker.ansible_facts.docker_container.State.Running }}"
+
+- set_fact:
+    portainer_endpoint: "http://{{ portainer_docker.ansible_facts.docker_container.NetworkSettings.IPAddress }}:{{ host_port }}/api"
+
+- name: "Check!!!"
+  debug:
+    msg: "{{ portainer_is_running }} // {{ portainer_endpoint }}"
+
+- name: Check container status
+  fail:
+    msg: "Portainer did not start: {{ portainer_is_running }}"
+  when: not portainer_is_running

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Install Docker-py
-  pip:
-    name: docker-py
-    state: present
-
 - include_tasks: clean-up.yml
 
 - include_tasks: install.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,15 +24,7 @@
 - include_tasks: endpoints.yml
   when: endpoints is not none
 
-- name: Configure Portainer settings
-  uri:
-    url: "{{ portainer_endpoint }}/settings"
-    method: PUT
-    return_content: true
-    headers:
-      Authorization: "{{ (auth_token.content|from_json).jwt }}"
-    body_format: json
-    body: "{{ lookup('template','settings.json.j2') }}"
+- include_tasks: settings.yml
   when: configure_settings
 
 - include_tasks: registry.yml

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -1,0 +1,13 @@
+---
+# - debug:
+#     msg: "{{ lookup('template', 'settings.json.j2') }}"
+
+- name: Configure Portainer settings
+  uri:
+    url: "{{ portainer_endpoint }}/settings"
+    method: PUT
+    return_content: true
+    headers:
+      Authorization: "{{ (auth_token.content|from_json).jwt }}"
+    body_format: json
+    body: "{{ lookup('template','settings.json.j2') }}"


### PR DESCRIPTION
# Features

 - add variable to configure container networks (for linking, e.g. LDAP)
 - don't expose container by default on host port

# Bugfixes

 - made the endpoints check less prone to error (I think I broke it in #6)

# Maintenance

 - enabled more tests on CircleCI
 - refactored settings into its own task file (and left some debug code)

# BC/Change

 - removed obsolete `docker-py`
 - documented dependency instead and added example
 - TL;DR: use `docker` lib instead

# Tests

https://circleci.com/gh/pngmbh/ansible-role-portainer/19 ✅ 