### PR TITLE
Fix: Task: Remove persistent data

### DIFF
--- a/tasks/clean-up.yml
+++ b/tasks/clean-up.yml
@@ -10,5 +10,5 @@
 - name: Remove persistent data
   file:
     state: absent
-    path: "{{ persistent_data_path.split(":")[0] }}"
+    path: "{{ persistent_data_path.split(\":\") | first | string }}"
   when: remove_persistent_data

--- a/tasks/clean-up.yml
+++ b/tasks/clean-up.yml
@@ -10,5 +10,5 @@
 - name: Remove persistent data
   file:
     state: absent
-    path: "{{ persistent_data_path }}"
+    path: "{{ persistent_data_path.split(":")[0] }}"
   when: remove_persistent_data


### PR DESCRIPTION
Fix: Task: Remove persistent data - Should not include full docker volume path when removing volume on host;

clean-yp.yml
When `persistent_data_path: /opt/portainer:/data` the path passed to Ansible file module will now be: `/opt/portainer` instead of the full docker volume path `/opt/portainer:/data`.

