### PR TITLE
Feature: Allow container image and name to be customised

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ configure_registry: false
 remove_persistent_data: false
 remove_existing_container: false
 persistent_data_path: /opt/portainer:/data
+container_image: portainer/portainer:{{ version }}
+container_name: portainer 
 container_labels: {}
 container_network:
 container_restart_policy: always

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,8 +1,8 @@
 ---
 - name: "Deploy Portainer to {{ inventory_hostname }}"
   community.docker.docker_container:
-    name: portainer
-    image: "portainer/portainer:{{ version }}"
+    name: "{{ container_name }}"
+    image: "{{ container_image }}"
     labels: "{{ container_labels | default(omit) }}"
     state: started
     detach: true


### PR DESCRIPTION
Useful in an offline environment to point to a Docker registry mirror, or a customized Portainer image.