### PR TITLE
fix(registry): http error 409 when registry with same url and credentials exists

### DIFF
--- a/tasks/registry.yml
+++ b/tasks/registry.yml
@@ -8,3 +8,4 @@
       Authorization: "{{ (auth_token.content|from_json).jwt }}"
     body_format: json
     body: "{{ lookup('template','registry.json.j2') }}"
+    status_code: [200, 409]


### PR DESCRIPTION
Accepts http code 409 as success.
Fixes the following error:

```ansible
TASK [shelleg.ansible_role_portainer : Configure Registry] ****************************************************************************************************************************************
fatal: [operations-test.local]: FAILED! => {"changed": false, "connection": "close", "content": "{\"message\":\"Another registry with the same URL and credentials already exists\",\"details\":\"A registry is already defined for this URL and credentials\"}\n", "content_length": "151", "content_type": "application/json", "date": "Tue, 08 Mar 2022 06:08:24 GMT", "elapsed": 0, "json": {"details": "A registry is already defined for this URL and credentials", "message": "Another registry with the same URL and credentials already exists"}, "msg": "Status code was 409 and not [200]: HTTP Error 409: Conflict", "redirected": false, "status": 409, "url": "http://172.17.0.2:9000/api/registries", "x_content_type_options": "nosniff", "x_xss_protection": "1; mode=block"}
```

Might also resolve the second mentioned error in #11 