### PR TITLE
fix(install): rest api is not available fast enough to create admin user

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -35,3 +35,13 @@
   fail:
     msg: "Portainer did not start: {{ portainer_is_running }}"
   when: not portainer_is_running
+
+- name: Wait for Portainer web interface to get available
+  uri:
+    url: "http://{{ portainer_docker.container.NetworkSettings.IPAddress }}:{{ host_port }}"
+    method: GET
+  register: wait_portainer_result
+  until: wait_portainer_result is succeeded
+  retries: 10
+  delay: 3
+  changed_when: false


### PR DESCRIPTION
Since I am providing the persistent data via NAS I am constantly facing an network error when executing the task `Configure admin user password`. It seems that Portainer needs more time for startup than with local storage.

I added an explicit wait for web interface availability.
It takes ~3-4 iterations (9-12 seconds) on my system to complete. With this change the task `Configure admin user password` never failed so far.